### PR TITLE
Updated dockerfile to use golang 1.15-alpine image

### DIFF
--- a/Dockerfile-ARM64v8
+++ b/Dockerfile-ARM64v8
@@ -1,4 +1,4 @@
-FROM arm64v8/golang:1.15
+FROM arm64v8/golang:1.15-alpine
 COPY . /app
 ENV NODE_ENV=production
 ENV CGO_ENABLED=0


### PR DESCRIPTION
* Updated arm64v8 dockerfile to use 1.15-alpine image. This has been confirmed working on the Raspberry Pi 4.